### PR TITLE
Treat near-zero distances as exact matches in IDW kernel

### DIFF
--- a/algos/IDW.py
+++ b/algos/IDW.py
@@ -112,10 +112,15 @@ def idw_interpolation_kernel(
 
                         if dist_sq < search_radius**2:
                             dist = ti.sqrt(dist_sq)
-                            if dist > 1e-6:
-                                weight = 1.0 / (dist**power_p)
-                                sum_weighted_z += weight * pz
-                                sum_weights += weight
+                            if dist <= 1e-6:
+                                # Treat near-zero distances as exact matches to avoid
+                                # numerical instability and dropping valid close points.
+                                exact_match_z = pz
+                                found_exact_match = True
+                                break
+                            weight = 1.0 / (dist**power_p)
+                            sum_weighted_z += weight * pz
+                            sum_weights += weight
                 if found_exact_match:
                     break
             if found_exact_match:

--- a/tests/test_IDW.py
+++ b/tests/test_IDW.py
@@ -78,29 +78,24 @@ def test_idw_kernel_point_very_close():
     """Test IDW kernel with a point very close to cell center (dist < 1e-6)."""
     # Cell center (0.5,0.5). Point is slightly offset.
     # dist = sqrt( (1e-7)^2 + 0 ) = 1e-7. This is < 1e-6.
-    # The kernel has `if dist > 1e-6: weight = 1.0 / (dist**power_p)`
-    # If dist is too small, it might get skipped or cause issues if not handled.
-    # The current kernel logic would skip weighting if dist <= 1e-6 but not an exact match.
-    # This means it might fall through to nodata if it's the only point.
-    # Let's test this behavior.
+    # Very small distances should be treated as exact matches so interpolation does
+    # not fall through to nodata due to floating point thresholding.
     offset = 1e-7
     points = np.array([[0.5 + offset, 0.5, 50.0]], dtype=np.float32)
     dtm_extent = (0.0, 0.0, 1.0, 1.0)
     nodata_val = -123.0
-    # With search_radius=1.0, this point is found.
-    # dist = 1e-7. This is NOT > 1e-6. So sum_weights remains 0. Cell gets nodata.
+    # With search_radius=1.0, this point should be treated as an exact match.
     dtm = idw(points, 1.0, 1.0, dtm_extent_user=dtm_extent, nodata_value=nodata_val)
     assert dtm.shape == (1, 1)
-    assert dtm[0, 0] == nodata_val
+    assert dtm[0, 0] == 50.0
 
     # What if there's another point further away that IS processed?
-    # Point1: (0.5 + 1e-7, 0.5, 50.0) -> dist=1e-7, skipped by `dist > 1e-6`
-    # Point2: (0.0, 0.0, 10.0) -> dist to cell center (0.5,0.5) is sqrt(0.5^2+0.5^2) = sqrt(0.5) approx 0.707
-    # This point *will* be weighted.
+    # Point1 is near-exact and should dominate as an exact match.
+    # Point2 is farther away and should not be considered once an exact match is found.
     points_2 = np.array([[0.5 + offset, 0.5, 50.0], [0.0, 0.0, 10.0]], dtype=np.float32)
     dtm_2 = idw(points_2, 1.0, 1.0, dtm_extent_user=dtm_extent, nodata_value=nodata_val)
     assert dtm_2.shape == (1, 1)
-    assert dtm_2[0, 0] == 10.0  # Only the second point contributes
+    assert dtm_2[0, 0] == 50.0
 
 
 def test_idw_kernel_no_suitable_neighbors():


### PR DESCRIPTION
### Motivation
- Points extremely close to a DTM cell center were neither caught by the `dist_sq == 0.0` exact-match branch nor included in weighting due to the `dist > 1e-6` threshold, which could incorrectly yield `nodata` or use a farther neighbor for interpolation.

### Description
- In `algos/IDW.py` the kernel now treats `dist <= 1e-6` as an exact match by setting `exact_match_z` and breaking out of the search loop to avoid numerical instability and dropped neighbors.
- The weighting path was simplified so that only distances greater than the tiny threshold are used to compute weights via `1.0 / (dist**power_p)`.
- Updated `tests/test_IDW.py` (`test_idw_kernel_point_very_close`) to expect a near-zero-distance point to be treated as the exact match (asserting the cell value equals the close point's elevation).

### Testing
- Compiled the modified files with `python -m compileall algos/IDW.py tests/test_IDW.py` and compilation succeeded.
- `pytest -q` could not be executed successfully in this environment because `numpy` is not installed and `pip` installation failed due to network/proxy restrictions, so test run was blocked by the environment (not by the code).
- The changes were committed with message: "Fix IDW handling for near-zero point distances".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfcd14c35c8322ae469b0daaaa61da)