### PR TITLE
🧹 Remove unused pytest import in test_IDW.py

### DIFF
--- a/tests/test_IDW.py
+++ b/tests/test_IDW.py
@@ -1,4 +1,3 @@
-import pytest
 import numpy as np
 from algos.IDW import idw
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `import pytest` from `tests/test_IDW.py`.
💡 **Why:** Having unused imports clutters the code, can lead to confusion for developers reading the test file, and triggers linter warnings. Removing it improves overall code maintainability and keeps imports clean.
✅ **Verification:** Verified by running `uv run ruff check tests/test_IDW.py` to ensure the unused import warning is gone and no new linting errors were introduced. Also used `python3 -m py_compile tests/test_IDW.py` to ensure basic syntax remains correct in the isolated environment.
✨ **Result:** A cleaner test file that adheres to code linting standards and has better readability without altering any existing test behavior.

---
*PR created automatically by Jules for task [17152675240274277221](https://jules.google.com/task/17152675240274277221) started by @lhemerly*