### PR TITLE
🔒 Fix: Prevent information exposure in Taichi initialization logs

### DIFF
--- a/algos/IDW.py
+++ b/algos/IDW.py
@@ -7,9 +7,8 @@ from algos.spatial_grid_index import SpatialGridIndex  # Import SpatialGridIndex
 try:
     ti.init(arch=ti.gpu, log_level=ti.WARN)
     print("Taichi initialized with GPU backend.")
-except Exception as e_gpu:
-    print(f"GPU backend for Taichi failed: {e_gpu}")
-    print("Falling back to CPU backend for Taichi.")
+except Exception:
+    print("GPU backend for Taichi failed. Falling back to CPU backend.")
     ti.init(arch=ti.cpu, log_level=ti.WARN)
     print("Taichi initialized with CPU backend.")
 

--- a/algos/__init__.py
+++ b/algos/__init__.py
@@ -1,8 +1,4 @@
-\
 from .simple_average import simple
 from .IDW import idw
 
-__all__ = [
-    "simple",
-    "idw"
-]
+__all__ = ["simple", "idw"]

--- a/algos/simple_average.py
+++ b/algos/simple_average.py
@@ -9,9 +9,8 @@ import taichi as ti  # Import the Taichi library
 try:
     ti.init(arch=ti.gpu)
     print("Taichi initialized with GPU backend.")
-except Exception as e_gpu:
-    print(f"GPU backend for Taichi failed: {e_gpu}")
-    print("Falling back to CPU backend for Taichi.")
+except Exception:
+    print("GPU backend for Taichi failed. Falling back to CPU backend.")
     ti.init(arch=ti.cpu)
     print("Taichi initialized with CPU backend.")
 

--- a/algos/spatial_grid_index.py
+++ b/algos/spatial_grid_index.py
@@ -77,6 +77,7 @@ def populate_indexed_points_kernel(
 
 # --- SPATIAL GRID INDEX CLASS ---
 
+
 @ti.data_oriented
 class SpatialGridIndex:
     def __init__(

--- a/parapoint/__init__.py
+++ b/parapoint/__init__.py
@@ -1,7 +1,4 @@
 from algos.simple_average import create_dtm_with_taichi_averaging
 from algos.IDW import create_dtm_with_taichi_idw
 
-__all__ = [
-    "create_dtm_with_taichi_averaging",
-    "create_dtm_with_taichi_idw"
-]
+__all__ = ["create_dtm_with_taichi_averaging", "create_dtm_with_taichi_idw"]

--- a/tests/test_IDW.py
+++ b/tests/test_IDW.py
@@ -1,4 +1,3 @@
-import pytest
 import numpy as np
 from algos.IDW import idw
 

--- a/tests/test_simple_average.py
+++ b/tests/test_simple_average.py
@@ -1,4 +1,3 @@
-import pytest
 import numpy as np
 from algos.simple_average import simple
 # Removed common_taichi import and _reset calls

--- a/tests/test_spatial_grid_index.py
+++ b/tests/test_spatial_grid_index.py
@@ -26,7 +26,7 @@ class TestSpatialGridIndex(unittest.TestCase):
             ti.init(
                 arch=ti.cpu, log_level=ti.INFO, default_fp=ti.f32, default_ip=ti.i32
             )
-        except Exception as e:
+        except Exception:
             # Log the error and re-raise to ensure the test framework knows setup failed.
             self.fail()
             raise


### PR DESCRIPTION
🎯 **What:** The raw `Exception` object was being formatted and printed to standard output when Taichi's GPU backend failed to initialize.
⚠️ **Risk:** If an unknown exception occurred, sensitive environmental details or stack traces could potentially leak to users or logs, leading to information exposure.
🛡️ **Solution:** Replaced the stringified exception with a generic error message ("GPU backend for Taichi failed. Falling back to CPU backend."), ensuring that only intended, safe information is communicated.

---
*PR created automatically by Jules for task [18358437819155617264](https://jules.google.com/task/18358437819155617264) started by @lhemerly*