### PR TITLE
🔒 Fix uncontrolled memory allocation DoS in DTM gridding algorithms

### DIFF
--- a/algos/IDW.py
+++ b/algos/IDW.py
@@ -170,8 +170,18 @@ def idw(
     # Using min_x, min_y from user/points and calculated width/height to derive actual DTM grid coverage
     min_x_dtm_grid = min_x
     min_y_dtm_grid = min_y
+
+    if dtm_resolution <= 0.0:
+        print("Error: dtm_resolution must be strictly positive.")
+        return np.array([[]], dtype=np.float32)
+
     grid_width = max(1, int(np.ceil((max_x - min_x_dtm_grid) / dtm_resolution)))
     grid_height = max(1, int(np.ceil((max_y - min_y_dtm_grid) / dtm_resolution)))
+
+    # Security fix: prevent massive memory allocations
+    if grid_width > 100000 or grid_height > 100000:
+        print(f"Error: Calculated DTM grid dimensions are too large ({grid_width}x{grid_height}). Uncontrolled memory allocation prevention.")
+        return np.array([[]], dtype=np.float32)
 
     # actual_max_x/y for DTM grid (used for SpatialGridIndex extent if it aligns with DTM)
     actual_dtm_grid_max_x = min_x_dtm_grid + grid_width * dtm_resolution

--- a/algos/simple_average.py
+++ b/algos/simple_average.py
@@ -99,6 +99,10 @@ def simple(
 
     print(f"DTM Extent: X({min_x:.2f} - {max_x:.2f}), Y({min_y:.2f} - {max_y:.2f})")
 
+    if dtm_resolution <= 0.0:
+        print("Error: dtm_resolution must be strictly positive.")
+        return np.array([[]], dtype=np.float32)
+
     # Calculate DTM grid dimensions
     grid_width = int(np.ceil((max_x - min_x) / dtm_resolution))
     grid_height = int(np.ceil((max_y - min_y) / dtm_resolution))
@@ -110,6 +114,11 @@ def simple(
             grid_width = 1
         if max_y == min_y:  # Typically for a single point row
             grid_height = 1
+
+    # Security fix: prevent massive memory allocations
+    if grid_width > 100000 or grid_height > 100000:
+        print(f"Error: Calculated DTM grid dimensions are too large ({grid_width}x{grid_height}). Uncontrolled memory allocation prevention.")
+        return np.array([[]], dtype=np.float32)
 
     # If after calculation, it's still zero (e.g. no points, or specific user extent)
     if grid_width <= 0 or grid_height <= 0:

--- a/test_dos.py
+++ b/test_dos.py
@@ -1,0 +1,23 @@
+import numpy as np
+from algos.IDW import idw
+from algos.simple_average import simple
+
+points = np.array([[0.0, 0.0, 10.0], [1000.0, 1000.0, 20.0]], dtype=np.float32)
+
+print("Testing IDW small resolution...")
+dtm = idw(points, 1e-4, 1.0)
+assert dtm.shape == (1, 0)
+
+print("Testing simple small resolution...")
+dtm_simple = simple(points, 1e-4)
+assert dtm_simple.shape == (1, 0)
+
+print("Testing zero resolution IDW...")
+dtm_zero = idw(points, 0.0, 1.0)
+assert dtm_zero.shape == (1, 0)
+
+print("Testing zero resolution simple...")
+dtm_zero_simple = simple(points, 0.0)
+assert dtm_zero_simple.shape == (1, 0)
+
+print("All tests passed!")

--- a/tests/test_IDW.py
+++ b/tests/test_IDW.py
@@ -45,6 +45,18 @@ def test_idw_nodata():
     assert dtm[0, 0] != -1  # This cell should have data
 
 
+def test_idw_dos_prevention():
+    """Test that extremely large grid dimensions due to tiny resolution or large extent are prevented."""
+    points = np.array([[0.0, 0.0, 10.0], [1000.0, 1000.0, 20.0]], dtype=np.float32)
+    # Resolution of 1e-4 with 1000 extent -> 10,000,000 grid cells per dimension (over max 100,000)
+    dtm = idw(points, 1e-4, 1.0)
+    assert dtm.shape == (1, 0)
+
+    # Test zero or negative resolution
+    dtm_zero_res = idw(points, 0.0, 1.0)
+    assert dtm_zero_res.shape == (1, 0)
+
+
 # Test with different power
 def test_idw_different_power():
     points = np.array([[0.5, 0.5, 10], [1.5, 1.5, 20]], dtype=np.float32)

--- a/tests/test_simple_average.py
+++ b/tests/test_simple_average.py
@@ -45,6 +45,18 @@ def test_simple_average_nodata():
     assert dtm[0, 1] == -1  # This cell should be nodata
 
 
+def test_simple_average_dos_prevention():
+    """Test that extremely large grid dimensions due to tiny resolution or large extent are prevented."""
+    points = np.array([[0.0, 0.0, 10.0], [1000.0, 1000.0, 20.0]], dtype=np.float32)
+    # Resolution of 1e-4 with 1000 extent -> 10,000,000 grid cells per dimension
+    dtm = simple(points, 1e-4)
+    assert dtm.shape == (1, 0)
+
+    # Test zero resolution
+    dtm_zero_res = simple(points, 0.0)
+    assert dtm_zero_res.shape == (1, 0)
+
+
 # Test with multiple points in one cell
 def test_simple_average_multiple_points_in_cell():
     points = np.array([[0.5, 0.5, 10], [0.6, 0.6, 20]], dtype=np.float32)


### PR DESCRIPTION
🎯 **What:** Fixed an uncontrolled memory allocation vulnerability in `algos/IDW.py` and `algos/simple_average.py`.

⚠️ **Risk:** If a user passed an extremely small `dtm_resolution` (e.g. `1e-10`) or coordinates that are extremely far apart, the computed `grid_width` and `grid_height` would be massively large. Allocating memory (via Taichi fields or NumPy arrays) with dimensions of $10^8$ or greater cells causes an immediate Out-Of-Memory (OOM) error, easily resulting in a Denial of Service (DoS) for any application consuming this library.

🛡️ **Solution:** 
- Ensured `dtm_resolution` is strictly positive (returning an empty array otherwise).
- Added bounds checks limiting `grid_width` and `grid_height` to 100,000 max. If exceeded, the function now prints an error and returns an empty array, matching the project's existing failure convention. 
- Included robust tests in `test_IDW.py` and `test_simple_average.py` to assert that zero or minuscule resolution limits return empty arrays and do not trigger massive array allocation.

---
*PR created automatically by Jules for task [2165758882530025367](https://jules.google.com/task/2165758882530025367) started by @lhemerly*