### PR TITLE
✨ Add advanced terrain metrics and Taichi smoothing filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The library provides methods for creating Digital Terrain Models (DTMs) from uno
 - **Multiple Algorithms:** Includes:
     - **Inverse Distance Weighting (IDW):** A common method for interpolating scattered data points.
     - **Simple Averaging:** A basic gridding approach that averages Z values of points falling within each grid cell.
+- **Advanced Terrain Metrics:** Calculate Slope, Aspect, Hillshade, Topographic Position Index (TPI), and Topographic Ruggedness Index (TRI).
+- **Post-Processing & Smoothing:** Includes Taichi-accelerated Gaussian filtering for noise reduction and iterative nodata gap filling.
 - **NumPy Integration:** Accepts and returns NumPy arrays, making it easy to integrate into existing Python workflows.
 - **Customizable:** Allows control over DTM resolution, extent, search radius (for IDW), and nodata values.
 
@@ -71,7 +73,19 @@ if dtm_idw.size > 0:
 else:
     print("IDW DTM is empty.")
 
-# Further processing or visualization of dtm_avg or dtm_idw can be done here.
+# --- Applying Post-Processing ---
+print("\n--- Smoothing and Filling Nodata ---")
+# Fill small gaps
+dtm_filled = parapoint.fill_nodata(dtm_idw, max_iterations=3, radius=1, nodata_value=-9999.0)
+# Smooth noise
+dtm_smoothed = parapoint.gaussian_filter(dtm_filled, sigma=1.0, radius=2, nodata_value=-9999.0)
+
+# --- Calculating Terrain Derivatives ---
+print("\n--- Calculating TPI and TRI ---")
+tpi = parapoint.calculate_tpi(dtm_smoothed, radius=2, nodata_value=-9999.0)
+tri = parapoint.calculate_tri(dtm_smoothed, nodata_value=-9999.0)
+
+# Further processing or visualization of dtm_avg, dtm_idw, or derivatives can be done here.
 # For example, using matplotlib or a GIS library like rasterio to save as GeoTIFF.
 
 # Example: Basic plot with Matplotlib (optional)

--- a/algos/smoothing.py
+++ b/algos/smoothing.py
@@ -1,0 +1,160 @@
+import numpy as np
+import taichi as ti
+
+# --- Taichi Initialization ---
+try:
+    ti.init(arch=ti.cpu, log_level=ti.WARN)
+    print("Taichi initialized with GPU backend.")
+except Exception as e_gpu:
+    print(f"GPU backend for Taichi failed: {e_gpu}")
+    print("Falling back to CPU backend for Taichi.")
+    ti.init(arch=ti.cpu, log_level=ti.WARN)
+    print("Taichi initialized with CPU backend.")
+
+
+@ti.kernel
+def gaussian_filter_kernel(
+    dtm: ti.types.ndarray(ti.f32, ndim=2),
+    out_dtm: ti.types.ndarray(ti.f32, ndim=2),
+    nodata_value: ti.f32,
+    rows: ti.i32,
+    cols: ti.i32,
+    sigma: ti.f32,
+    radius: ti.i32,
+):
+    # Standard deviation calculation is done outside in Python to avoid redundant kernel ops
+    # The kernel itself will construct the weights dynamically for simplicity.
+    # In a more optimized version, weights could be pre-computed and passed as an array.
+
+    # 2 * sigma^2
+    two_sigma_sq = 2.0 * sigma * sigma
+    pi = 3.14159265359
+
+    for r, c in ti.ndrange(rows, cols):
+        if dtm[r, c] == nodata_value:
+            out_dtm[r, c] = nodata_value
+        else:
+            weight_sum = 0.0
+            val_sum = 0.0
+            for i in range(-radius, radius + 1):
+                for j in range(-radius, radius + 1):
+                    # Check boundaries
+                    nr = r + i
+                    nc = c + j
+                    if 0 <= nr < rows and 0 <= nc < cols:
+                        neighbor_val = dtm[nr, nc]
+                        if neighbor_val != nodata_value:
+                            # Calculate Gaussian weight
+                            dist_sq = ti.cast(i * i + j * j, ti.f32)
+                            weight = ti.exp(-dist_sq / two_sigma_sq) / (
+                                pi * two_sigma_sq
+                            )
+                            val_sum += neighbor_val * weight
+                            weight_sum += weight
+
+            if weight_sum > 0.0:
+                out_dtm[r, c] = val_sum / weight_sum
+            else:
+                out_dtm[r, c] = dtm[r, c]  # Should not happen ideally
+
+
+@ti.kernel
+def fill_nodata_kernel(
+    dtm: ti.types.ndarray(ti.f32, ndim=2),
+    out_dtm: ti.types.ndarray(ti.f32, ndim=2),
+    nodata_value: ti.f32,
+    rows: ti.i32,
+    cols: ti.i32,
+    radius: ti.i32,
+) -> ti.i32:
+    cells_filled = 0
+    for r, c in ti.ndrange(rows, cols):
+        if dtm[r, c] == nodata_value:
+            val_sum = 0.0
+            count = 0
+            for i in range(-radius, radius + 1):
+                for j in range(-radius, radius + 1):
+                    nr = r + i
+                    nc = c + j
+                    if 0 <= nr < rows and 0 <= nc < cols:
+                        if i != 0 or j != 0:
+                            neighbor_val = dtm[nr, nc]
+                            if neighbor_val != nodata_value:
+                                val_sum += neighbor_val
+                                count += 1
+            if count > 0:
+                out_dtm[r, c] = val_sum / ti.cast(count, ti.f32)
+                ti.atomic_add(cells_filled, 1)
+            else:
+                out_dtm[r, c] = nodata_value
+        else:
+            out_dtm[r, c] = dtm[r, c]
+    return cells_filled
+
+
+def gaussian_filter(
+    dtm: np.ndarray,
+    sigma: float = 1.0,
+    radius: int = 2,
+    nodata_value: float = -9999.0,
+) -> np.ndarray:
+    """
+    Applies a Gaussian filter to smooth the DTM, reducing noise.
+
+    Args:
+        dtm (np.ndarray): The input Digital Terrain Model.
+        sigma (float): The standard deviation of the Gaussian distribution.
+        radius (int): The radius of the kernel (e.g., 2 means a 5x5 kernel).
+        nodata_value (float): The nodata value to ignore.
+
+    Returns:
+        np.ndarray: The smoothed DTM.
+    """
+    if dtm.size == 0 or dtm.ndim != 2:
+        return np.array([[]], dtype=np.float32)
+
+    rows, cols = dtm.shape
+    dtm_f32 = dtm.astype(np.float32)
+    out_dtm = np.empty_like(dtm_f32)
+
+    gaussian_filter_kernel(dtm_f32, out_dtm, nodata_value, rows, cols, sigma, radius)
+
+    return out_dtm
+
+
+def fill_nodata(
+    dtm: np.ndarray,
+    max_iterations: int = 5,
+    radius: int = 1,
+    nodata_value: float = -9999.0,
+) -> np.ndarray:
+    """
+    Iteratively fills nodata gaps in the DTM using the mean of valid neighbors.
+
+    Args:
+        dtm (np.ndarray): The input Digital Terrain Model with nodata gaps.
+        max_iterations (int): Maximum number of passes to fill larger gaps.
+        radius (int): The search radius for neighbors (e.g., 1 is a 3x3 window).
+        nodata_value (float): The nodata value to replace.
+
+    Returns:
+        np.ndarray: The DTM with filled nodata values.
+    """
+    if dtm.size == 0 or dtm.ndim != 2:
+        return np.array([[]], dtype=np.float32)
+
+    rows, cols = dtm.shape
+    current_dtm = dtm.astype(np.float32).copy()
+    out_dtm = np.empty_like(current_dtm)
+
+    for i in range(max_iterations):
+        cells_filled = fill_nodata_kernel(
+            current_dtm, out_dtm, nodata_value, rows, cols, radius
+        )
+        # Swap arrays for the next iteration
+        current_dtm[:] = out_dtm
+
+        if cells_filled == 0:
+            break  # No more cells could be filled
+
+    return current_dtm

--- a/algos/terrain_derivatives.py
+++ b/algos/terrain_derivatives.py
@@ -190,8 +190,8 @@ def tpi_kernel(
                 mean_z = sum_z / ti.cast(count, ti.f32)
                 out_tpi[r, c] = dtm[r, c] - mean_z
             else:
-                # No valid neighbors, TPI is 0
-                out_tpi[r, c] = 0.0
+                # No valid neighbors, return nodata_value
+                out_tpi[r, c] = nodata_value
 
 
 @ti.kernel

--- a/algos/terrain_derivatives.py
+++ b/algos/terrain_derivatives.py
@@ -158,3 +158,124 @@ def calculate_terrain_derivatives(
         )
 
     return {"slope": out_slope, "aspect": out_aspect, "hillshade": out_hillshade}
+
+
+@ti.kernel
+def tpi_kernel(
+    dtm: ti.types.ndarray(ti.f32, ndim=2),
+    out_tpi: ti.types.ndarray(ti.f32, ndim=2),
+    nodata_value: ti.f32,
+    rows: ti.i32,
+    cols: ti.i32,
+    radius: ti.i32,
+):
+    for r, c in ti.ndrange(rows, cols):
+        if dtm[r, c] == nodata_value:
+            out_tpi[r, c] = nodata_value
+        else:
+            sum_z = 0.0
+            count = 0
+            for i in range(-radius, radius + 1):
+                for j in range(-radius, radius + 1):
+                    nr = r + i
+                    nc = c + j
+                    if 0 <= nr < rows and 0 <= nc < cols:
+                        if i != 0 or j != 0:
+                            neighbor_val = dtm[nr, nc]
+                            if neighbor_val != nodata_value:
+                                sum_z += neighbor_val
+                                count += 1
+
+            if count > 0:
+                mean_z = sum_z / ti.cast(count, ti.f32)
+                out_tpi[r, c] = dtm[r, c] - mean_z
+            else:
+                # No valid neighbors, TPI is 0
+                out_tpi[r, c] = 0.0
+
+
+@ti.kernel
+def tri_kernel(
+    dtm: ti.types.ndarray(ti.f32, ndim=2),
+    out_tri: ti.types.ndarray(ti.f32, ndim=2),
+    nodata_value: ti.f32,
+    rows: ti.i32,
+    cols: ti.i32,
+):
+    for r, c in ti.ndrange(rows, cols):
+        if dtm[r, c] == nodata_value:
+            out_tri[r, c] = nodata_value
+        else:
+            sum_diff_sq = 0.0
+            count = 0
+            center_val = dtm[r, c]
+            for i in range(-1, 2):
+                for j in range(-1, 2):
+                    nr = r + i
+                    nc = c + j
+                    if 0 <= nr < rows and 0 <= nc < cols:
+                        if i != 0 or j != 0:
+                            neighbor_val = dtm[nr, nc]
+                            if neighbor_val != nodata_value:
+                                sum_diff_sq += ti.abs(center_val - neighbor_val)
+                                count += 1
+
+            if count > 0:
+                out_tri[r, c] = sum_diff_sq
+            else:
+                out_tri[r, c] = 0.0
+
+
+def calculate_tpi(
+    dtm: np.ndarray,
+    radius: int = 1,
+    nodata_value: float = -9999.0,
+) -> np.ndarray:
+    """
+    Calculates the Topographic Position Index (TPI) for a DTM.
+    TPI compares the elevation of each cell to the mean elevation of a specified neighborhood.
+
+    Args:
+        dtm (np.ndarray): The input Digital Terrain Model.
+        radius (int): The radius of the neighborhood (e.g., 1 means a 3x3 window).
+        nodata_value (float): The nodata value to ignore.
+
+    Returns:
+        np.ndarray: The TPI array.
+    """
+    if dtm.size == 0 or dtm.ndim != 2:
+        return np.array([[]], dtype=np.float32)
+
+    rows, cols = dtm.shape
+    dtm_f32 = dtm.astype(np.float32)
+    out_tpi = np.empty_like(dtm_f32)
+
+    tpi_kernel(dtm_f32, out_tpi, nodata_value, rows, cols, radius)
+
+    return out_tpi
+
+
+def calculate_tri(
+    dtm: np.ndarray,
+    nodata_value: float = -9999.0,
+) -> np.ndarray:
+    """
+    Calculates the Topographic Ruggedness Index (TRI) for a DTM using Riley et al. (1999) approach (sum of abs differences).
+
+    Args:
+        dtm (np.ndarray): The input Digital Terrain Model.
+        nodata_value (float): The nodata value to ignore.
+
+    Returns:
+        np.ndarray: The TRI array.
+    """
+    if dtm.size == 0 or dtm.ndim != 2:
+        return np.array([[]], dtype=np.float32)
+
+    rows, cols = dtm.shape
+    dtm_f32 = dtm.astype(np.float32)
+    out_tri = np.empty_like(dtm_f32)
+
+    tri_kernel(dtm_f32, out_tri, nodata_value, rows, cols)
+
+    return out_tri

--- a/parapoint/__init__.py
+++ b/parapoint/__init__.py
@@ -1,7 +1,12 @@
 from algos.simple_average import simple
 from algos.IDW import idw
 from algos.min_max import min_z, max_z
-from algos.terrain_derivatives import calculate_terrain_derivatives
+from algos.terrain_derivatives import (
+    calculate_terrain_derivatives,
+    calculate_tpi,
+    calculate_tri,
+)
+from algos.smoothing import gaussian_filter, fill_nodata
 
 # Legacy aliases for backward compatibility
 create_dtm_with_taichi_averaging = simple
@@ -13,6 +18,10 @@ __all__ = [
     "min_z",
     "max_z",
     "calculate_terrain_derivatives",
+    "calculate_tpi",
+    "calculate_tri",
+    "gaussian_filter",
+    "fill_nodata",
     "create_dtm_with_taichi_averaging",
     "create_dtm_with_taichi_idw",
 ]

--- a/tests/test_smoothing.py
+++ b/tests/test_smoothing.py
@@ -1,0 +1,69 @@
+import numpy as np
+from algos.smoothing import gaussian_filter, fill_nodata
+
+
+def test_gaussian_filter_basic():
+    dtm = np.array(
+        [[10.0, 10.0, 10.0], [10.0, 20.0, 10.0], [10.0, 10.0, 10.0]], dtype=np.float32
+    )
+
+    # Smooth with a large sigma to blur the spike
+    smoothed = gaussian_filter(dtm, sigma=1.0, radius=1, nodata_value=-9999.0)
+
+    # The center value should be significantly reduced from 20
+    assert smoothed[1, 1] < 20.0
+    # The corners should be slightly pulled up
+    assert smoothed[0, 0] > 10.0
+
+
+def test_gaussian_filter_nodata():
+    dtm = np.array(
+        [[10.0, 10.0, 10.0], [10.0, -9999.0, 10.0], [10.0, 10.0, 10.0]],
+        dtype=np.float32,
+    )
+
+    smoothed = gaussian_filter(dtm, sigma=1.0, radius=1, nodata_value=-9999.0)
+
+    # The nodata value should remain nodata
+    assert smoothed[1, 1] == -9999.0
+    # A neighbor should only average the valid values
+    # In this uniform case, averaging 10s should result in ~10
+    assert np.isclose(smoothed[0, 1], 10.0)
+
+
+def test_fill_nodata_basic():
+    dtm = np.array(
+        [[10.0, 10.0, 10.0], [10.0, -9999.0, 10.0], [10.0, 10.0, 10.0]],
+        dtype=np.float32,
+    )
+
+    filled = fill_nodata(dtm, max_iterations=1, radius=1, nodata_value=-9999.0)
+
+    # Center should be filled with the average of its 8 neighbors (all 10.0)
+    assert filled[1, 1] == 10.0
+
+
+def test_fill_nodata_iterative():
+    dtm = np.array(
+        [[10.0, -9999.0, -9999.0], [10.0, -9999.0, -9999.0], [10.0, 10.0, 10.0]],
+        dtype=np.float32,
+    )
+
+    # 1 iteration might not fill the top right corner
+    filled_1 = fill_nodata(dtm, max_iterations=1, radius=1, nodata_value=-9999.0)
+    assert filled_1[0, 2] == -9999.0
+
+    # More iterations should fill it
+    filled_3 = fill_nodata(dtm, max_iterations=3, radius=1, nodata_value=-9999.0)
+    assert filled_3[0, 2] != -9999.0
+    assert filled_3[0, 2] > 0
+
+
+def test_empty_arrays():
+    empty_dtm = np.array([[]], dtype=np.float32)
+
+    res1 = gaussian_filter(empty_dtm)
+    assert res1.size == 0
+
+    res2 = fill_nodata(empty_dtm)
+    assert res2.size == 0

--- a/tests/test_terrain_derivatives.py
+++ b/tests/test_terrain_derivatives.py
@@ -1,5 +1,9 @@
 import numpy as np
-from algos.terrain_derivatives import calculate_terrain_derivatives
+from algos.terrain_derivatives import (
+    calculate_terrain_derivatives,
+    calculate_tpi,
+    calculate_tri,
+)
 
 
 def test_calculate_terrain_derivatives():
@@ -39,3 +43,51 @@ def test_terrain_derivatives_empty():
     assert res["slope"].size == 0
     assert res["aspect"].size == 0
     assert res["hillshade"].size == 0
+
+
+def test_tpi_basic():
+    # 3x3 plane, center should have TPI 0
+    dtm = np.array(
+        [[10.0, 10.0, 10.0], [10.0, 10.0, 10.0], [10.0, 10.0, 10.0]], dtype=np.float32
+    )
+
+    tpi = calculate_tpi(dtm, radius=1, nodata_value=-9999.0)
+    # Center cell mean of 8 neighbors is 10. 10 - 10 = 0.
+    assert np.isclose(tpi[1, 1], 0.0)
+
+    # Peak
+    dtm_peak = np.array(
+        [[10.0, 10.0, 10.0], [10.0, 20.0, 10.0], [10.0, 10.0, 10.0]], dtype=np.float32
+    )
+
+    tpi_peak = calculate_tpi(dtm_peak, radius=1, nodata_value=-9999.0)
+    # Mean of neighbors is 10. Center is 20. TPI = 10.
+    assert np.isclose(tpi_peak[1, 1], 10.0)
+
+
+def test_tpi_empty():
+    res = calculate_tpi(np.array([[]], dtype=np.float32))
+    assert res.size == 0
+
+
+def test_tri_basic():
+    # 3x3 plane, TRI should be 0
+    dtm = np.array(
+        [[10.0, 10.0, 10.0], [10.0, 10.0, 10.0], [10.0, 10.0, 10.0]], dtype=np.float32
+    )
+
+    tri = calculate_tri(dtm, nodata_value=-9999.0)
+    assert np.isclose(tri[1, 1], 0.0)
+
+    # Center diff = 1 with all neighbors -> sum of diffs = 8
+    dtm_bump = np.array(
+        [[10.0, 10.0, 10.0], [10.0, 11.0, 10.0], [10.0, 10.0, 10.0]], dtype=np.float32
+    )
+
+    tri_bump = calculate_tri(dtm_bump, nodata_value=-9999.0)
+    assert np.isclose(tri_bump[1, 1], 8.0)
+
+
+def test_tri_empty():
+    res = calculate_tri(np.array([[]], dtype=np.float32))
+    assert res.size == 0

--- a/tests/test_terrain_derivatives.py
+++ b/tests/test_terrain_derivatives.py
@@ -70,6 +70,22 @@ def test_tpi_empty():
     assert res.size == 0
 
 
+def test_tpi_no_valid_neighbors():
+    # Center is valid, all neighbors are nodata
+    dtm = np.array(
+        [
+            [-9999.0, -9999.0, -9999.0],
+            [-9999.0, 10.0, -9999.0],
+            [-9999.0, -9999.0, -9999.0],
+        ],
+        dtype=np.float32,
+    )
+
+    tpi = calculate_tpi(dtm, radius=1, nodata_value=-9999.0)
+    # TPI should be nodata since there are no valid neighbors
+    assert tpi[1, 1] == -9999.0
+
+
 def test_tri_basic():
     # 3x3 plane, TRI should be 0
     dtm = np.array(


### PR DESCRIPTION
Added a comprehensive set of new Taichi-accelerated features to Parapoint to give users more powerful analytical capabilities out-of-the-box.

**New Terrain Metrics:**
- **Topographic Position Index (TPI):** Added `calculate_tpi` for measuring relative elevation against a local neighborhood.
- **Topographic Ruggedness Index (TRI):** Added `calculate_tri` for quantifying terrain heterogeneity.

**New Post-Processing Module:**
- **Gaussian Smoothing:** Implemented `gaussian_filter` for effective noise reduction in raw LiDAR DTMs.
- **Nodata Gap Filling:** Implemented `fill_nodata` for iterative, focal mean-based interpolation of missing data cells.

Tested with Pytest, formatted with Ruff, and documented in the README.

---
*PR created automatically by Jules for task [7179585765207405139](https://jules.google.com/task/7179585765207405139) started by @lhemerly*